### PR TITLE
added suggest command

### DIFF
--- a/bot/extensions/suggest.py
+++ b/bot/extensions/suggest.py
@@ -1,0 +1,20 @@
+from discord.ext.commands import Cog, command
+from discord import Embed
+
+class suggest(Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @command(name='suggest', help='give suggestion', usage='suggest')
+    async def suggest(self, ctx, suggestion):
+        suggestion_channel = self.bot.get_channel(841968280168300574)
+
+        embed = Embed(
+            color=self.bot.default_color,
+            description=f"{suggestion} \n \n  {ctx.message.author.name}",
+        )
+        await suggestion_channel.send(embed=embed);
+
+def setup(bot):
+    bot.add_cog(suggest(bot))
+


### PR DESCRIPTION
I have added a suggest command which enables members to suggest things . the member can suggest by using ::suggest "their suggestion" and after this the suggestion is sent as a embed in the suggestion channel also send the username by whom it was sent so people cant hide when they send offensive stuff  . Also after this command has been merged with with the main branch we can clear the suggestion channel and lock it so only admins and grace can send messages . 
see the screenshot below also the channel id has been changed to match code society's suggestion channel 
![screen](https://user-images.githubusercontent.com/77972850/126157792-e5dee8ed-7837-4d0b-916f-35ca3c98a172.jpg)
![screen2](https://user-images.githubusercontent.com/77972850/126157794-7ee285a3-88ca-45d1-988a-51e8c04455d5.jpg)
