### PR TITLE
Dm channel only

### DIFF
--- a/bot/extensions/poll_cog.py
+++ b/bot/extensions/poll_cog.py
@@ -127,7 +127,7 @@ class PollCog(Cog):
 
 	async def get_options(self, ctx: Context, options_count: int = 2) -> Optional[List[Option]]:
 		def check(m: Message) -> bool:
-			return ctx.author == m.author
+			return ctx.author == m.author and ctx.channel == m.author.dm_channel
 
 		options: List[Option] = []
 		emojis: List[str] = self.get_emojis(options_count)


### PR DESCRIPTION
Before, you could just send a message in the channel where you created the poll and it will count it as an actual option input. So this PR fixes the issue by checking if the messages were sent in DM channel 