### PR TITLE
Fix possible issue with View timeout

### DIFF
--- a/bot/extensions/poll_cog.py
+++ b/bot/extensions/poll_cog.py
@@ -30,6 +30,7 @@ async def create_poll_embed(poll: Poll) -> Embed:
 class PollView(TimedView):
 	def __init__(self, poll: Poll, embed: Embed, winner_callback: Callable, seconds: int):
 		super().__init__(seconds=seconds)
+		self.timeout = None
 
 		self.__poll: Poll = poll
 		self.__embed: Embed = embed


### PR DESCRIPTION
When I was testing the Poll on the server, after like 15 minutes, timer stops the countdown and doesn't go any further, and any interactions with Buttons fail. The possible issue is that the View, by default, has a timeout value of something. So sooner or later it will stop working. This pr fixes it by setting the timeout value to None. (This fix is only for the interaction issue I believe, but since the timer is closely related to the View, when it times out, it might cause issues for it as well.)