### PR TITLE
edited the embed for welcome message

### DIFF
--- a/bot/extensions/welcome_cog.py
+++ b/bot/extensions/welcome_cog.py
@@ -76,11 +76,10 @@ class WelcomeCog(Cog, name="Welcome", description="Welcomes new members"):
         """
         info(f"{ctx.author.display_name} asked to get welcomed!")
 
-        embed = Embed(color=self.bot.default_color)
-        embed.add_field(
-            name="The Code Society Server",
-            value=self.get_welcome_message(ctx.author),
-            inline=False
+        embed = Embed(
+            color=self.bot.default_color,
+            title="The Code Society Server",
+            description=self.get_welcome_message(ctx.author),
         )
 
         await ctx.send(embed=embed, ephemeral=True)


### PR DESCRIPTION
I researched why we sometimes got the member's ID instead of the name. I changed the embed to get the message from the description instead of the value.