### PR TITLE
Fix embed mention

### DIFF
--- a/bot/extensions/threads_cog.py
+++ b/bot/extensions/threads_cog.py
@@ -142,6 +142,8 @@ class ThreadsCog(Cog, name="Threads"):
 
     async def post_thread(self, thread: Thread):
         channel = self.bot.get_channel(self.threads_channel_id)
+        role_id = app.config.get("threads", "role_id")
+        content = f"<@&{role_id}>" if role_id else None
 
         embed = Embed(
             color=self.bot.default_color,
@@ -150,7 +152,7 @@ class ThreadsCog(Cog, name="Threads"):
         )
 
         if channel:
-            message = await channel.send(embed=embed)
+            message = await channel.send(content=content, embed=embed)
             await message.create_thread(name=thread.title)
 
     @hybrid_group(name="threads", help="Commands to manage threads")

--- a/bot/extensions/welcome_cog.py
+++ b/bot/extensions/welcome_cog.py
@@ -7,7 +7,7 @@ from discord import Embed
 class WelcomeCog(Cog, name="Welcome", description="Welcomes new members"):
     """A cog that sends a welcome message to new members when they join the server."""
 
-    BASE_WELCOME_MESSAGE = "Hi <@{member_id}> ({member_name})! Welcome to the **Code Society**."
+    BASE_WELCOME_MESSAGE = "Hi {member_name}! Welcome to the **Code Society**."
 
     def __init__(self, bot):
         self.bot = bot
@@ -42,7 +42,7 @@ class WelcomeCog(Cog, name="Welcome", description="Welcomes new members"):
             self.BASE_WELCOME_MESSAGE,
             self.help_section,
             self.info_section,
-        ])).strip().format(member_id=member.id, member_name=member.name)
+        ])).strip().format(member_name=member.display_name)
 
     def __build_section(self, channel_names, message):
         """Builds a section of the welcome message by replacing placeholders with corresponding channel IDs.
@@ -77,18 +77,19 @@ class WelcomeCog(Cog, name="Welcome", description="Welcomes new members"):
         if not before.bot and (before.pending and not after.pending):
             info(f"{after.display_name} accepted the rules!")
 
-            welcome_channel = self.bot.get_channel_by_name("welcome")
-            if not welcome_channel:
-                welcome_channel = before.bot.system_channel
-
             embed = Embed(color=self.bot.default_color)
+            welcome_channel = self.bot.get_channel_by_name("welcome")
+
+            if not welcome_channel:
+                welcome_channel = before.guild.system_channel
+
             embed.add_field(
                 name="The Code Society Server",
                 value=self.get_welcome_message(after),
                 inline=False
             )
 
-            await welcome_channel.send(embed=embed)
+            await welcome_channel.send(f"<@{after.id}>", embed=embed)
 
     @Cog.listener()
     async def on_member_join(self, member):

--- a/config/settings.cfg
+++ b/config/settings.cfg
@@ -21,6 +21,7 @@ api_key = ${GITHUB_API}
 
 [threads]
 channel_id = ${THREADS_CHANNEL_ID}
+role_id = ${THREADS_ROLE_ID}
 
 [moderation]
 ; Minimum amount of days before a user can join the server


### PR DESCRIPTION
This is a fix for issue #123. In adds a mention outside the embed for the welcome message and automatic threads. Along with the role mention for the threads, a new configuration as been added to optionally include the role id that we want to ping. 

Threads
![image](https://github.com/user-attachments/assets/884bc57c-52fb-4b07-89f2-22b251662d15)

Welcome message
![image](https://github.com/user-attachments/assets/8bea69bb-da75-421b-95d3-c4f22e361410)
